### PR TITLE
Fix typo in .gitignore

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -1,1 +1,1 @@
-__pychache__
+__pycache__


### PR DESCRIPTION
This PR fixes a typo in the .gitignore file, that didn't match the __pycache__ folder and files correctly.